### PR TITLE
Capture textual comments from commented blocks and export them to sheet

### DIFF
--- a/ImportadorSAGE.py
+++ b/ImportadorSAGE.py
@@ -247,7 +247,9 @@ def write_to_sheet(doc, sheet_name, pontos_importados, modo, config):
         sheet.getCellByPosition(1, row_idx).setString(ponto['type'])
         if ponto['type'] in [CODIGO_COMENTARIO_SIMPLES, CODIGO_INCLUDE, CODIGO_INCLUDE_COMENTADO]:
             sheet.getCellByPosition(2, row_idx).setString(ponto.get('data', ''))
-        elif 'attributes' in ponto:
+        elif ponto['type'] == CODIGO_BLOCO_COMENTADO:
+            sheet.getCellByPosition(2, row_idx).setString(ponto.get('comment', ''))
+        if 'attributes' in ponto:
             for attr_key, attr_value in ponto['attributes'].items():
                 try: col_idx = cabecalhos.index(attr_key); sheet.getCellByPosition(col_idx, row_idx).setString(attr_value)
                 except ValueError: pass
@@ -376,15 +378,22 @@ def parse_dat_file(file_path, relative_path, all_data, entidades_validas):
                 # Lógica para Bloco Comentado (Ex: ;CGS / ;COR)
                 entidade_nome_comentado = match.group(1).upper()
                 ponto = {'type': CODIGO_BLOCO_COMENTADO, 'identifier': entidade_nome_comentado, 'attributes': {}, 'origem': relative_path}
+                comentarios_textuais = []
                 
                 # Assume que o bloco comentado é da última entidade ativa conhecida
                 chave_a_usar = entidade_nome_comentado.lower() 
                 
                 while i < len(lines) and lines[i].strip().startswith(';'):
                     attr_line = lines[i].strip()[1:].strip()
-                    if '=' in attr_line: key, value = attr_line.split('=', 1); ponto['attributes'][key.strip()] = value.strip()
+                    if '=' in attr_line:
+                        key, value = attr_line.split('=', 1)
+                        ponto['attributes'][key.strip()] = value.strip()
+                    elif attr_line:
+                        comentarios_textuais.append(attr_line)
                     i += 1
                 
+                if comentarios_textuais:
+                    ponto['comment'] = "\n".join(comentarios_textuais)
                 all_data.setdefault(chave_a_usar, []).append(ponto)
             else:
                 # Lógica para Comentário Simples (FORA de qualquer bloco)


### PR DESCRIPTION
### Motivation
- Preserve textual notes found inside commented entity blocks so they are not lost during import.
- Surface those notes in the spreadsheet under the existing "Comentario/Include" column to improve export fidelity.

### Description
- In `parse_dat_file` (ImportadorSAGE.py) collect non-attribute lines that begin with `;` inside a commented block into a `comentarios_textuais` list and store them as `ponto['comment']` when present. 
- In `write_to_sheet` (ImportadorSAGE.py) write `ponto['comment']` into the `Comentario/Include` column for entries with `type == CODIGO_BLOCO_COMENTADO` while still writing attributes to their columns. 
- The change preserves existing handling for includes and simple comments and ensures both comment text and attributes are emitted for commented blocks.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aaba9aff08329a95dba549234fdad)