### PR TITLE
Attach pending comments to next active block

### DIFF
--- a/ImportadorSAGE.py
+++ b/ImportadorSAGE.py
@@ -303,6 +303,7 @@ def parse_dat_file(file_path, relative_path, all_data, entidades_validas):
     i = 0
     # Inicializa a chave de entidade com o nome do arquivo (como fallback)
     current_entidade_chave = os.path.splitext(os.path.basename(file_path))[0].lower()
+    pending_comments = []
     
     while i < len(lines):
         line = lines[i].strip()
@@ -336,6 +337,9 @@ def parse_dat_file(file_path, relative_path, all_data, entidades_validas):
             current_entidade_chave = entidade_nome.lower() # Atualiza a chave para 'cor'
             
             ponto = {'type': CODIGO_BLOCO_ATIVO, 'identifier': entidade_nome, 'attributes': {}, 'origem': relative_path}
+            if pending_comments:
+                ponto['comment'] = "\n".join(pending_comments)
+                pending_comments = []
             
             # INICIA A LEITURA DAS LINHAS DENTRO DO BLOCO
             while i < len(lines):
@@ -389,7 +393,7 @@ def parse_dat_file(file_path, relative_path, all_data, entidades_validas):
             else:
                 # Lógica para Comentário Simples (FORA de qualquer bloco)
                 comentario_limpo = original_line.lstrip(';').lstrip()
-                all_data.setdefault(current_entidade_chave, []).append({'type': CODIGO_COMENTARIO_SIMPLES, 'data': comentario_limpo, 'origem': relative_path})
+                pending_comments.append(comentario_limpo)
             continue
 
 # ===============================================================


### PR DESCRIPTION
### Motivation
- Ensure simple comments that appear outside of a block in `.dat` files are preserved and associated with the next active block by buffering them during parsing in `parse_dat_file`.

### Description
- In `ImportadorSAGE.py` added a local `pending_comments` list inside `parse_dat_file`, appended out-of-block simple comments to this queue, and when an active block is encountered attached the queued comments to the created `ponto` as `ponto['comment']` and cleared the queue.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aaba12368832992c7a6606b9c1108)